### PR TITLE
🐛 Fix urllib3 LibreSSL compatibility and update CLI command references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ install-dev:
 
 # Run the application
 run: check-env
-	python -m social_scrubber
+	social-scrubber
 
 # Check if .env file exists
 check-env:

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@
    ```bash
    make run
    # or
-   python -m social_scrubber
+   social-scrubber
    # or
-   ./social-scrubber
+   python -m social_scrubber
    ```
 
 ### Manual Setup
@@ -74,7 +74,7 @@ If you prefer not to use Make:
 
 4. Run the tool:
    ```bash
-   python -m social_scrubber
+   social-scrubber
    ```
 
 ## Configuration
@@ -140,7 +140,7 @@ LOG_LEVEL=INFO              # DEBUG, INFO, WARNING, ERROR
 Run the tool in interactive mode for a guided experience:
 
 ```bash
-python -m social_scrubber
+social-scrubber
 ```
 
 The interactive mode will:
@@ -155,20 +155,22 @@ You can also use command-line options to override configuration:
 
 ```bash
 # Run in dry-run mode (safe - won't actually delete)
-python -m social_scrubber --dry-run
+social-scrubber --dry-run
 
 # Actually delete posts (be careful!)
-python -m social_scrubber --no-dry-run
+social-scrubber --no-dry-run
 
 # Process only specific platforms
-python -m social_scrubber --platforms bluesky,mastodon
+social-scrubber --platforms bluesky,mastodon
 
 # Limit number of posts per platform
-python -m social_scrubber --max-posts 5
+social-scrubber --max-posts 5
 
 # Custom date range
-python -m social_scrubber --start-date 2024-01-01T00:00:00 --end-date 2024-01-31T23:59:59
+social-scrubber --start-date 2024-01-01T00:00:00 --end-date 2024-01-31T23:59:59
 ```
+
+> **Note**: You can also use `python -m social_scrubber` if you prefer the module syntax.
 
 ### Development Commands
 If you're developing or contributing:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ atproto>=0.0.44
 python-dateutil>=2.8.2
 requests>=2.31.0
 pydantic>=2.5.0
+urllib3<2.0  # Pin to v1.x for macOS LibreSSL compatibility


### PR DESCRIPTION
## 🐛 Bug Fix & Enhancement

This PR addresses the urllib3 LibreSSL compatibility warning on macOS and improves the CLI user experience by standardizing command references.

## 🔧 Changes Made

### urllib3 Compatibility Fix
- **Pin urllib3 to v1.x** (`urllib3<2.0`) in `requirements.txt`
- Resolves the `NotOpenSSLWarning` that appears on macOS systems using LibreSSL
- Maintains compatibility without requiring OpenSSL upgrades

### CLI Command Standardization
- **Updated README.md** to use `social-scrubber` (with dashes) as the primary CLI command
- **Updated Makefile** `run` target to use `social-scrubber` command
- Added backward compatibility note for `python -m social_scrubber` syntax
- Follows common CLI naming conventions (dashes vs underscores)

## 🧪 Testing

- ✅ Verified `social-scrubber --help` works without warnings
- ✅ Confirmed `python -m social_scrubber` still works as alternative
- ✅ Tested `make run` uses updated command
- ✅ All existing functionality preserved

## 📝 Files Changed

- `requirements.txt` - Added urllib3 version constraint
- `README.md` - Updated CLI command examples and added compatibility note
- `Makefile` - Updated run target to use new command format

## 🎯 Benefits

- **Cleaner UX**: No more urllib3 warnings cluttering terminal output
- **Better CLI conventions**: Dash-separated commands are more intuitive
- **Backward compatible**: Both command formats continue to work
- **Future-proof**: Prevents urllib3 v2 compatibility issues

## 🔍 Before/After

**Before:**
```bash
python -m social_scrubber --help
# Output includes LibreSSL warning
```

**After:**
```bash
social-scrubber --help
# Clean output, no warnings
```

---

**Ready for review and merge!** 🚀