### PR TITLE
fix: correct archive prompt default and fix .env parsing errors

### DIFF
--- a/social_scrubber/cli.py
+++ b/social_scrubber/cli.py
@@ -651,7 +651,7 @@ async def _run_archive(scrubber, selected_platforms):
     for platform_name, posts in all_posts.items():
         if posts:
             display_posts_table(posts, f"{platform_name.title()} Posts")
-    if not confirm_action(f"Archive {total_posts} posts?", default=False):
+    if not confirm_action(f"Archive {total_posts} posts?", default=True):
         console.print("Archiving cancelled.")
         return
     for platform_name, posts in all_posts.items():


### PR DESCRIPTION
This PR fixes two UI/UX issues discovered during testing of the archive command:

## 🐛 Issues Fixed

### 1. Archive Confirmation Prompt
**Problem**: Archive confirmation showed `Archive X posts? [y/N]:` instead of `Archive X posts? [Y/n]:`
- This made it seem like 'N' (no) was the default, which is counterintuitive for an archive operation
- Users expect 'Y' (yes) to be the default for non-destructive operations like archiving

**Solution**: Changed `default=False` to `default=True` in `confirm_action()` call
- Now shows `Archive X posts? [Y/n]:` indicating 'Y' is the default
- Better user experience - just pressing Enter will proceed with archiving

### 2. python-dotenv Parsing Errors
**Problem**: Console showed parsing errors on startup:
```
python-dotenv could not parse statement starting at line 6
python-dotenv could not parse statement starting at line 7
```

**Solution**: Fixed `.env` file comment format
- Changed semicolon comments (`;`) to hash comments (`#`) on lines 6-7
- python-dotenv only supports `#` for comments, not `;`
- Clean startup with no error messages

## ✅ Testing
- [x] Archive command now shows correct `[Y/n]` prompt
- [x] No more python-dotenv parsing errors on startup
- [x] Archive functionality works as expected
- [x] All existing tests still pass

## 📝 Files Changed
- `social_scrubber/cli.py` - Fixed archive confirmation prompt default
- `.env` - Fixed comment format from semicolon to hash

Small but important UX improvements that make the tool more polished and user-friendly! 🚀